### PR TITLE
Deleted non printable characters

### DIFF
--- a/scripts/kernel_compilation_steps.txt
+++ b/scripts/kernel_compilation_steps.txt
@@ -1,34 +1,34 @@
-STEP 1: ​
+STEP 1:
 /*
  *removes all the temporary folder, object files, images generated during the previous build. 
  *This step also deletes the .config file if created previously 
- */ ​
-make ARCH=arm distclean​
+ */
+make ARCH=arm distclean
 
-STEP 2:​
-/*creates a .config file by using default config file given by the vendor */ ​
+STEP 2:
+/*creates a .config file by using default config file given by the vendor */
 
-make ARCH=arm bb.org_defconfig​
+make ARCH=arm bb.org_defconfig
 
 
-STEP 3:​
+STEP 3:
 /*This step is optional. Run this command only if you want to change some kernel settings before compilation */ ​
 
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- menuconfig​
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- menuconfig
 
-​
-STEP 4:​
+
+STEP 4:
 /*Kernel source code compilation. This stage creates a kernel image "uImage" also all the device tree source files will be compiled, and dtbs will be generated */ ​
 
-​make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- uImage dtbs LOADADDR=0x80008000 -j4​
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- uImage dtbs LOADADDR=0x80008000 -j4
 
-STEP 5:​
-/*This step builds and generates in-tree loadable(M) kernel modules(.ko) */​
+STEP 5:
+/*This step builds and generates in-tree loadable(M) kernel modules(.ko) */
 
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-  modules  -j4​
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-  modules  -j4
 
-STEP 6:​
+STEP 6:
 /* This step installs all the generated .ko files in the default path of the computer (/lib/modules/<kernel_ver>) */​
 
-sudo make ARCH=arm  modules_install​
+sudo make ARCH=arm  modules_install
 


### PR DESCRIPTION
There were some non printable characters in `kernel_compilation_steps.txt`. For example:

```
echo sudo make ARCH=arm  modules_install​ | xxd
00000000: 7375 646f 206d 616b 6520 4152 4348 3d61  sudo make ARCH=a
00000010: 726d 206d 6f64 756c 6573 5f69 6e73 7461  rm modules_insta
00000020: 6c6c e280 8b0a                           ll....
```
These characters were causing errors when people were trying to copy and paste the commands. For example search "No rule to make target 'modules_install​'" in the Q&A section. This is the correct solution to that problem. I removed the non printable characters for future students.