### PR TITLE
Update pcd_platform_driver_dt.c

### DIFF
--- a/custom_drivers/005_pcd_platform_driver_dt/pcd_platform_driver_dt.c
+++ b/custom_drivers/005_pcd_platform_driver_dt/pcd_platform_driver_dt.c
@@ -272,19 +272,19 @@ struct pcdev_platform_data* pcdev_get_platdata_from_dt(struct device *dev)
 		return ERR_PTR(-ENOMEM);
 	}
 
-	if(of_property_read_string(dev_node,"org,device-serial-num",&pdata->serial_number) ){
+	if(of_property_read_string(dev_node,"org-device-serial-num",&pdata->serial_number) ){
 		dev_info(dev,"Missing serial number property\n");
 		return ERR_PTR(-EINVAL);
 
 	}
 
 
-	if(of_property_read_u32(dev_node,"org,size",&pdata->size) ){
+	if(of_property_read_u32(dev_node,"org-size",&pdata->size) ){
 		dev_info(dev,"Missing size property\n");
 		return ERR_PTR(-EINVAL);
 	}
 
-	if(of_property_read_u32(dev_node,"org,perm",&pdata->perm) ){
+	if(of_property_read_u32(dev_node,"org-device-permission",&pdata->perm) ){
 		dev_info(dev,"Missing permission property\n");
 		return ERR_PTR(-EINVAL);
 	}
@@ -441,7 +441,7 @@ static int __init pcd_platform_driver_init(void)
 	}
 
 	/*2. Create device class under /sys/class */
-	pcdrv_data.class_pcd = class_create(THIS_MODULE,"pcd_class");
+	pcdrv_data.class_pcd = class_create("pcd_class");
 	if(IS_ERR(pcdrv_data.class_pcd)){
 		pr_err("Class creation failed\n");
 		ret = PTR_ERR(pcdrv_data.class_pcd);


### PR DESCRIPTION
1. Fixed the compilation issues with Linux 6.8.0-rc7 by removing a parameter from ''class_create" api
2. In am335x-boneblack-ldd1.dtsi which created under  /linux-master/arch/arm/boot/ti/omap/am335x-boneblack-ldd1.dtsi

/ {
	pcdev-1 {
		compatible = 
		org-size = 
		org-device-serial-num = 
		org-device-permission = 
_________________________________________ 
dtb properties are not aligned to the "pcdev_get_platdata_from_dt" api causing failure in loading the kernal module